### PR TITLE
set correct keycloak version pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,7 @@
   <url>http://www.example.com</url>
 
   <properties>
-    <!-- TODO: Change this to Keycloak 22 once it is released -->
-    <keycloak.version>999.0.0-SNAPSHOT</keycloak.version>
+    <keycloak.version>22.0.0</keycloak.version>
 
     <!-- Openshift client and it's dependencies -->
     <openshift-client.version>9.0.5.Final</openshift-client.version>


### PR DESCRIPTION
the `mvn clean install` fails unless the correct keycloak version is set in the pom.xml file. And there is no mention in the Readme as well.